### PR TITLE
Before compiling Jade insert Mardown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ public/
 node_modules/
 .sass-cache/
 bower_components/
+.tmp/

--- a/app/templates/base.jade
+++ b/app/templates/base.jade
@@ -6,4 +6,5 @@ html(lang="en")
   body
     h1 Jade - node template engine
     #container.col
-      include:md ../../content/test.md
+      //- inject:mdPath
+      //- endinject

--- a/content/2015-04-28_12-28_perdu.com.md
+++ b/content/2015-04-28_12-28_perdu.com.md
@@ -1,0 +1,5 @@
+# Perdu sur l'Internet ?
+
+## Pas de panique, on va vous aider
+
+ **<pre>    * <----- vous êtes ici</pre>**

--- a/content/2015-04-28_14-47_aws-sdk-js.md
+++ b/content/2015-04-28_14-47_aws-sdk-js.md
@@ -1,0 +1,54 @@
+# AWS SDK for JavaScript
+
+[![NPM](https://nodei.co/npm/aws-sdk.svg?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/aws-sdk/)
+
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.svg)](https://gitter.im/aws/aws-sdk-js)
+
+[![Version](https://badge.fury.io/js/aws-sdk.svg)](http://badge.fury.io/js/aws-sdk) [![Build Status](https://travis-ci.org/aws/aws-sdk-js.svg?branch=master)](https://travis-ci.org/aws/aws-sdk-js) [![Coverage Status](https://coveralls.io/repos/aws/aws-sdk-js/badge.svg?branch=master)](https://coveralls.io/r/aws/aws-sdk-js?branch=master)
+
+The official AWS SDK for JavaScript, available for browsers and mobile devices,
+or Node.js backends
+
+Release notes can be found at http://aws.amazon.com/releasenotes/SDK/JavaScript
+
+## Installing
+
+### In the Browser
+
+To use the SDK in the browser, simply add the following script tag to your
+HTML pages:
+
+    <script src="https://sdk.amazonaws.com/js/aws-sdk-2.1.26.min.js"></script>
+
+The AWS SDK is also compatible with [browserify](http://browserify.org).
+
+### In Node.js
+
+The preferred way to install the AWS SDK for Node.js is to use the
+[npm](http://npmjs.org) package manager for Node.js. Simply type the following
+into a terminal window:
+
+```sh
+npm install aws-sdk
+```
+
+### Using Bower
+
+You can also use [Bower](http://bower.io) to install the SDK by typing the
+following into a terminal window:
+
+```sh
+bower install aws-sdk-js
+```
+
+## Usage and Getting Started
+
+You can find a getting started guide at:
+
+http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/
+
+## License
+
+This SDK is distributed under the
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0),
+see LICENSE.txt and NOTICE.txt for more information.

--- a/content/test.md
+++ b/content/test.md
@@ -1,1 +1,5 @@
 Hello
+Hello
+Hello
+Hello
+Hello

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,27 +8,19 @@ var gulp = require('gulp'),
     connect = require('gulp-connect')
     concat = require('gulp-concat')
     uglify = require('gulp-uglify')
-    markdown = require('gulp-markdown')
     jade = require('gulp-jade')
-    livereload = require('gulp-livereload');
+    inject = require('gulp-inject');
 
 var config = {
     sassPath: './app/resources/sass',
     bowerDir: './bower_components',
-    jadeTemplatePath: './app/templates'
+    jadeTemplatePath: './app/templates',
+    markdownPath: './content'
 }
 
 gulp.task('bower', function() {
     return bower()
         .pipe(gulp.dest(config.bowerDir))
-});
-
-gulp.task('sass', function() {
-    return sass('source/')
-    .on('error', function (err) {
-      console.error('Error!', err.message);
-   })
-    .pipe(gulp.dest('result'));
 });
 
 gulp.task('icons', function() {
@@ -54,7 +46,8 @@ gulp.task('css', function() {
             })))
         .pipe(autoprefix('last 2 version'))
         .pipe(gulp.dest('./public/css'))
-        .pipe(livereload());
+        .pipe(notify({ message: 'CSS complete' }))
+        .pipe(connect.reload());
 });
 
 
@@ -68,41 +61,44 @@ gulp.task('js', function(){
     .pipe(gulp.dest('./public/js'));;
 });
 
-// Converts Markdown to HTML
-gulp.task('markdown', function () {
-    return gulp.src('./content/*.md')
-        .pipe(markdown())
-        .pipe(gulp.dest('./public/md/'))
-        .pipe(notify({ message: 'Markdown to HTML task complete' }));
-});
-
-
-// Converts Jade to HTML (jade is including markdown files)
-gulp.task('jade', ['markdown'], function() {  // ['markdown'] forces jade to wait
-    return gulp.src(config.jadeTemplatePath+'/*.jade')
-    .pipe(
-      jade(
-        {pretty: true}
-        ))
-        .pipe(gulp.dest('./public/'))
-        .pipe(livereload())
-        .pipe(notify({ message: 'Jade to HTML task complete' }));
-});
-
 gulp.task('serve', function () {
   connect.server({
-    root: ['public'],
+    root: ['./public'],
     port: 8000,
     livereload: true
   });
 });
 
-
 // Rerun the task when a file changes
 gulp.task('watch', ['serve'], function() {
     gulp.watch(config.sassPath + '/**/*.scss', ['css']);
-    gulp.watch('./content/*.md', ['markdown']);
-    gulp.watch(config.jadeTemplatePath+'/*.jade', ['jade'])
+    gulp.watch('./content/*.md', ['inject-mdPath-in-jade']);
+    gulp.watch(config.jadeTemplatePath+'/*.jade', ['inject-mdPath-in-jade'])
 });
 
-gulp.task('default', ['bower', 'icons', 'css', 'js', 'markdown', 'jade']);
+// Inject markdown to jade && compile jade to html
+gulp.task('inject-mdPath-in-jade', function () {
+  var markdownInjectFile = gulp.src(config.markdownPath + '/*.md', { read: false });
+
+  var markdownInjectOptions = {
+    starttag: '//- inject:mdPath',
+    addPrefix: '../..',
+    addRootSlash: false,
+    transform: function (filepath, file, i, length) {
+      return 'include:markdown ' + filepath;
+    }
+  };
+
+  return gulp.src(config.jadeTemplatePath + '/base.jade')
+    .pipe(inject(markdownInjectFile, markdownInjectOptions))
+    .pipe(gulp.dest('./.tmp/base.jade'))
+    .pipe(notify({ message: 'Markdown injected in base.jade' }))
+    .pipe(jade({
+      pretty: true
+    }))
+    .pipe(gulp.dest('./public/'))
+    .pipe(connect.reload())
+    .pipe(notify({ message: 'Jade to HTML task complete' }));
+});
+
+gulp.task('default', ['bower', 'icons', 'css', 'js', 'inject-mdPath-in-jade' ]);

--- a/package.json
+++ b/package.json
@@ -5,14 +5,10 @@
     "gulp-bower": "0.0.6",
     "gulp-concat": "^2.5.2",
     "gulp-connect": "^2.2.0",
-    "gulp-livereload": "^3.8.0",
+    "gulp-inject": "^1.2.0",
+    "gulp-jade": "^1.0.0",
     "gulp-notify": "^1.6.0",
     "gulp-ruby-sass": "^0.7.1",
     "gulp-uglify": "^1.2.0"
-  },
-  "dependencies": {
-    "gulp-jade": "~1.0.0",
-    "gulp-markdown": "~1.0.0",
-    "markdown": "~0.5.0"
   }
 }


### PR DESCRIPTION
- Add .editorconfig, markdown sample
- Fix reload on watch (gulp-livereload is unnecessary) 
- Before compiling Jade insert Mardown
- Mardown to HTML is managed by Jade (gulp-markdown is unnecessary)
